### PR TITLE
feat(office365): simplify mailbox access

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: place_calendar
-version: 4.22.1
+version: 4.23.0
 
 crystal: ">= 0.36.1"
 


### PR DESCRIPTION
when a user has a calendar added into their calendar list, we attempt to route requests through the users mailbox
  /users/{user_email}/calendars/{cal_id_from_cal_list}/events/{event_id}/decline
however this adds complexity and potential points of confusion, so we should probably default to using mailboxes directly
  /users/{calendar_email}/calendar/calendarView

we default to trying to access things via the calendar list to handle shared calendars but this is really the outlier.
The shared calendar list routes would still work as long as a calendar_id instead of a mailbox is specified
